### PR TITLE
fix: restore teardown script with route-table cleanup

### DIFF
--- a/scripts/Remove-SmbReadyFoundation.ps1
+++ b/scripts/Remove-SmbReadyFoundation.ps1
@@ -1,0 +1,354 @@
+<#
+.SYNOPSIS
+    Removes all SMB Ready Foundation resources from an Azure subscription.
+
+.DESCRIPTION
+    This script completely tears down all resources deployed by the SMB Ready Foundation,
+    including resource groups, policy assignments, role assignments, and budgets.
+
+    Use this script to:
+    - Clean up after a failed deployment
+    - Remove a SMB Ready Foundation before redeployment
+    - Decommission a customer's SMB Ready Foundation
+
+    Resources are deleted in proper dependency order to avoid conflicts.
+
+.PARAMETER Location
+    Azure region where the SMB Ready Foundation was deployed. Used to derive resource names.
+    Valid values: swedencentral, germanywestcentral
+
+.PARAMETER Environment
+    The environment suffix used in spoke resource group naming.
+    Valid values: dev, staging, prod
+
+.PARAMETER WaitForCompletion
+    If specified, waits for all resource group deletions to complete.
+    Otherwise, deletions are initiated asynchronously.
+
+.PARAMETER Force
+    Skip confirmation prompt.
+
+.EXAMPLE
+    .\Remove-SmbReadyFoundation.ps1 -Location swedencentral
+    # Interactive removal with confirmation
+
+.EXAMPLE
+    .\Remove-SmbReadyFoundation.ps1 -Location swedencentral -Force -WaitForCompletion
+    # Force removal and wait for completion
+
+.NOTES
+    Version: 1.1
+    Author: Agentic InfraOps
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('swedencentral', 'germanywestcentral')]
+    [string]$Location,
+
+    [Parameter()]
+    [ValidateSet('dev', 'staging', 'prod')]
+    [string]$Environment = 'prod',
+
+    [Parameter()]
+    [switch]$WaitForCompletion,
+
+    [Parameter()]
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Continue'
+
+#region Helper Functions
+
+function Write-Step {
+    param([string]$Message, [string]$Status = 'INFO')
+    $color = switch ($Status) {
+        'OK'      { 'Green' }
+        'WARN'    { 'Yellow' }
+        'ERROR'   { 'Red' }
+        'SKIP'    { 'Gray' }
+        default   { 'White' }
+    }
+    $symbol = switch ($Status) {
+        'OK'      { '✓' }
+        'WARN'    { '⚠' }
+        'ERROR'   { '✗' }
+        'SKIP'    { '○' }
+        default   { '•' }
+    }
+    Write-Host "  $symbol $Message" -ForegroundColor $color
+}
+
+function Remove-ResourceIfExists {
+    param(
+        [string]$ResourceType,
+        [string]$ResourceName,
+        [string]$ResourceGroup = $null,
+        [scriptblock]$DeleteCommand
+    )
+
+    try {
+        & $DeleteCommand 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Step "$ResourceType '$ResourceName' deleted" 'OK'
+            return $true
+        } else {
+            Write-Step "$ResourceType '$ResourceName' not found or already deleted" 'SKIP'
+            return $false
+        }
+    } catch {
+        Write-Step "$ResourceType '$ResourceName' deletion failed: $_" 'ERROR'
+        return $false
+    }
+}
+
+#endregion
+
+#region Main Script
+
+# Banner
+Write-Host ""
+Write-Host "╔═══════════════════════════════════════════════════════════════════╗" -ForegroundColor Red
+Write-Host "║  SMB READY FOUNDATION REMOVAL                                         ║" -ForegroundColor Red
+Write-Host "╚═══════════════════════════════════════════════════════════════════╝" -ForegroundColor Red
+Write-Host ""
+
+# Calculate resource names
+$regionAbbrev = @{
+    'swedencentral'      = 'swc'
+    'germanywestcentral' = 'gwc'
+}[$Location]
+
+$resourceGroups = @(
+    "rg-hub-smb-$regionAbbrev",
+    "rg-spoke-$Environment-$regionAbbrev",
+    "rg-monitor-smb-$regionAbbrev",
+    "rg-backup-smb-$regionAbbrev",
+    "rg-migrate-smb-$regionAbbrev"
+)
+
+# Check authentication
+Write-Host "  Checking Azure authentication..." -ForegroundColor Gray
+try {
+    $account = az account show --output json 2>$null | ConvertFrom-Json
+    Write-Step "Subscription: $($account.name)" 'OK'
+} catch {
+    Write-Step "Not authenticated. Run: az login" 'ERROR'
+    exit 1
+}
+
+$subId = $account.id
+
+# List what will be deleted
+Write-Host ""
+Write-Host "  The following resources will be PERMANENTLY DELETED:" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "  Resource Groups:" -ForegroundColor White
+foreach ($rg in $resourceGroups) {
+    $exists = az group exists --name $rg 2>$null
+    if ($exists -eq 'true') {
+        Write-Host "    • $rg" -ForegroundColor Red
+    } else {
+        Write-Host "    • $rg (not found)" -ForegroundColor Gray
+    }
+}
+
+Write-Host ""
+Write-Host "  Subscription-Level Resources:" -ForegroundColor White
+Write-Host "    • Policy assignments: smb-*" -ForegroundColor Red
+Write-Host "    • Budget: budget-smb-monthly" -ForegroundColor Red
+Write-Host "    • Role assignments for backup policy" -ForegroundColor Red
+Write-Host ""
+
+# Confirmation
+if (-not $Force) {
+    $confirmation = Read-Host "  Type 'DELETE' to confirm removal"
+    if ($confirmation -ne 'DELETE') {
+        Write-Host ""
+        Write-Step "Removal cancelled" 'WARN'
+        exit 0
+    }
+}
+
+Write-Host ""
+Write-Host "  ─── Starting Removal ───" -ForegroundColor Yellow
+Write-Host ""
+
+# Phase 1: Delete policy assignments
+Write-Host "  Phase 1: Policy Assignments" -ForegroundColor Cyan
+$policies = az policy assignment list --scope "/subscriptions/$subId" `
+    --query "[?starts_with(name, 'smb-')].name" -o tsv 2>$null
+
+if ($policies) {
+    $policyList = $policies -split "`n" | Where-Object { $_ }
+    foreach ($policy in $policyList) {
+        Remove-ResourceIfExists -ResourceType 'Policy' -ResourceName $policy -DeleteCommand {
+            az policy assignment delete --name $policy --scope "/subscriptions/$subId"
+        }
+    }
+} else {
+    Write-Step "No smb-* policy assignments found" 'SKIP'
+}
+
+# Phase 2: Delete budget
+Write-Host ""
+Write-Host "  Phase 2: Budget" -ForegroundColor Cyan
+Remove-ResourceIfExists -ResourceType 'Budget' -ResourceName 'budget-smb-monthly' -DeleteCommand {
+    az consumption budget delete --budget-name 'budget-smb-monthly'
+}
+
+# Phase 3: Delete stale role assignments
+Write-Host ""
+Write-Host "  Phase 3: Role Assignments" -ForegroundColor Cyan
+
+# Find role assignments with orphaned principals (service principals that no longer exist)
+$roleAssignments = az role assignment list --scope "/subscriptions/$subId" `
+    --query "[?contains(roleDefinitionName, 'Backup') || contains(roleDefinitionName, 'Contributor')].{name:name, principal:principalId, role:roleDefinitionName}" `
+    -o json 2>$null | ConvertFrom-Json
+
+$deletedCount = 0
+foreach ($ra in $roleAssignments) {
+    # Check if principal still exists
+    $exists = az ad sp show --id $ra.principal 2>$null
+    if (-not $exists -and $LASTEXITCODE -ne 0) {
+        # Orphaned role assignment - delete it
+        $raId = "/subscriptions/$subId/providers/Microsoft.Authorization/roleAssignments/$($ra.name)"
+        az role assignment delete --ids $raId 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Step "Orphaned role assignment deleted (principal: $($ra.principal.Substring(0,8))...)" 'OK'
+            $deletedCount++
+        }
+    }
+}
+if ($deletedCount -eq 0) {
+    Write-Step "No orphaned role assignments found" 'SKIP'
+}
+
+# Phase 4: Delete firewall resources (if stuck in failed state)
+Write-Host ""
+Write-Host "  Phase 4: Firewall & VPN Gateway Cleanup (if faulted)" -ForegroundColor Cyan
+$hubRg = "rg-hub-smb-$regionAbbrev"
+$hubExists = az group exists --name $hubRg 2>$null
+
+if ($hubExists -eq 'true') {
+    # Check firewall state
+    $fwState = az network firewall show -g $hubRg -n "fw-hub-smb-$regionAbbrev" `
+        --query 'provisioningState' -o tsv 2>$null
+
+    if ($fwState -eq 'Failed') {
+        Write-Step "Faulted firewall detected - cleaning up..." 'WARN'
+
+        # Delete firewall
+        az network firewall delete -g $hubRg -n "fw-hub-smb-$regionAbbrev" --no-wait 2>$null
+        Write-Step "Firewall deletion initiated" 'OK'
+
+        # Wait a moment for firewall to start deleting
+        Start-Sleep -Seconds 10
+
+        # Delete firewall policy
+        az network firewall policy delete -g $hubRg -n "fwpol-hub-smb-$regionAbbrev" 2>$null
+        Write-Step "Firewall policy deleted" 'OK'
+    } elseif ($fwState) {
+        Write-Step "Firewall state: $fwState (will be deleted with resource group)" 'SKIP'
+    } else {
+        Write-Step "No firewall found" 'SKIP'
+    }
+
+    # Check VPN Gateway state
+    $vpnState = az network vnet-gateway show -g $hubRg -n "vpng-hub-smb-$regionAbbrev" `
+        --query 'provisioningState' -o tsv 2>$null
+
+    if ($vpnState -eq 'Failed') {
+        Write-Step "Faulted VPN Gateway detected - cleaning up..." 'WARN'
+
+        # Delete VPN Gateway
+        az network vnet-gateway delete -g $hubRg -n "vpng-hub-smb-$regionAbbrev" --no-wait 2>$null
+        Write-Step "VPN Gateway deletion initiated" 'OK'
+
+        # Wait for deletion to start
+        Start-Sleep -Seconds 10
+
+        # Delete orphaned VPN public IP
+        $vpnPipName = "pip-vpn-smb-$regionAbbrev"
+        $vpnPipExists = az network public-ip show -g $hubRg -n $vpnPipName 2>$null
+        if ($LASTEXITCODE -eq 0 -and $vpnPipExists) {
+            az network public-ip delete -g $hubRg -n $vpnPipName 2>$null
+            Write-Step "VPN Gateway public IP deleted: $vpnPipName" 'OK'
+        }
+    } elseif ($vpnState) {
+        Write-Step "VPN Gateway state: $vpnState (will be deleted with resource group)" 'SKIP'
+    } else {
+        Write-Step "No VPN Gateway found" 'SKIP'
+    }
+} else {
+    Write-Step "Hub resource group not found" 'SKIP'
+}
+
+# Phase 4b: Delete route tables (prevent hub RG deletion failure)
+Write-Host ""
+Write-Host "  Phase 4b: Route Table Cleanup" -ForegroundColor Cyan
+
+if ($hubExists -eq 'true') {
+    $routeTables = az network route-table list -g $hubRg --query "[].name" -o tsv 2>$null
+    if ($routeTables) {
+        $rtList = $routeTables -split "`n" | Where-Object { $_ }
+        foreach ($rt in $rtList) {
+            az network route-table delete -g $hubRg -n $rt 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Step "Route table '$rt' deleted" 'OK'
+            } else {
+                Write-Step "Route table '$rt' deletion failed" 'ERROR'
+            }
+        }
+    } else {
+        Write-Step "No route tables found in hub RG" 'SKIP'
+    }
+} else {
+    Write-Step "Hub resource group not found" 'SKIP'
+}
+
+# Phase 5: Delete resource groups
+Write-Host ""
+Write-Host "  Phase 5: Resource Groups" -ForegroundColor Cyan
+
+$deletedRgs = @()
+foreach ($rg in $resourceGroups) {
+    $exists = az group exists --name $rg 2>$null
+    if ($exists -eq 'true') {
+        if ($WaitForCompletion) {
+            Write-Step "Deleting $rg (waiting for completion)..." 'INFO'
+            az group delete --name $rg --yes 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Step "$rg deleted" 'OK'
+            } else {
+                Write-Step "$rg deletion failed" 'ERROR'
+            }
+        } else {
+            az group delete --name $rg --yes --no-wait 2>$null
+            Write-Step "$rg deletion initiated (async)" 'OK'
+            $deletedRgs += $rg
+        }
+    } else {
+        Write-Step "$rg not found" 'SKIP'
+    }
+}
+
+# Summary
+Write-Host ""
+Write-Host "  ─── Removal Complete ───" -ForegroundColor Green
+Write-Host ""
+
+if ($deletedRgs.Count -gt 0 -and -not $WaitForCompletion) {
+    Write-Host "  Resource group deletions running in background." -ForegroundColor Yellow
+    Write-Host "  Monitor with:" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "    az group list -o table | grep -E 'smb|spoke'" -ForegroundColor Cyan
+    Write-Host ""
+}
+
+Write-Host "  Subscription is ready for a new SMB Ready Foundation deployment." -ForegroundColor Green
+Write-Host ""
+
+#endregion


### PR DESCRIPTION
## Summary

Restores `scripts/Remove-SmbReadyFoundation.ps1` (354 lines) which was inadvertently removed during an upstream sync (95701e6). The restored version includes the **Phase 4b route-table cleanup** fix originally authored on `test/deploy-all-scenarios` (commit 179dc92).

## Why

- `main` currently has no teardown script for `infra/bicep/smb-ready-foundation/`.
- Route tables in the hub RG blocked RG deletion in firewall and full scenarios because Azure couldn't remove `rt-spoke-smb-swc` while subnet associations existed.
- Phase 4b enumerates and deletes all route tables in the hub RG before Phase 5 RG deletion.

## Validation

- [x] PowerShell parse: **OK** (`[System.Management.Automation.Language.Parser]::ParseFile`)
- [x] PSScriptAnalyzer Severity=Error: **0 findings**
- [x] Pre-push hooks: all passed (deprecated-refs, json-syntax, terminology, version-sync, branch-naming/scope)
- [ ] Live teardown on firewall scenario (recommended follow-up on next real teardown)

## Source

Cherry-picked content from commit [`179dc92`](https://github.com/jonathan-vella/azure-smb-rf/commit/179dc92) on the abandoned `test/deploy-all-scenarios` branch. Since the file didn't exist on main, a standard `git cherry-pick` was not possible, so the file was restored via `git checkout 179dc92 -- <path>`.

Originally authored by @jonathan-vella.